### PR TITLE
Updated to fix bug with section shortcode slug arg

### DIFF
--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 		public static function get_section_by_slug( $slug ) {
 			$args = array(
 				'post_type'   => 'ucf_section',
-				'post_name'   => $slug,
+				'name'        => $slug,
 				'numberposts' => 1,
 			);
 


### PR DESCRIPTION
Bug Fix:
* Corrects bug where first of all sections is returned because the param for query by slug is `name` and not `post_name`.