### PR TITLE
Don't access global $post properties if $post obj is not set

### DIFF
--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -187,6 +187,8 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 			global $post;
 			$sections = array();
 
+			if ( !$post ) { return $sections; } // Abort if $post is not set
+
 			if ( $post->post_type == 'ucf_section' ) {
 				$sections[] = $post;
 			}


### PR DESCRIPTION
Fixes some notices thrown by `UCF_Section_Common::get_post_sections()` when the global `$post` object is not available (e.g. on category/tag archives, or when a 404 is returned).