### PR TITLE
Added null check

### DIFF
--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 
 			$post = $wp_query->get_queried_object();
 
-			if ( get_class( $post ) !== 'WP_Post' ) {
+			if ( $post !== null && get_class( $post ) !== 'WP_Post' ) {
 				$post = null;
 			}
 


### PR DESCRIPTION
Bug Fixes:
* Added a null check before checking to see if `$post` is a `WP_Post` object. Silences a warning thrown when the check is performed in the admin screens.

Resolves #26 