### PR TITLE
Section Fetch!

### DIFF
--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -34,7 +34,9 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 			if ( isset( $attr['slug'] ) ) {
 				if ( $post ) {
 					$section =  isset( $post->sections['posts'][$attr['slug']] ) ? $post->sections['posts'][$attr['slug']] : null;
-				} else {
+				}
+
+				if ( ! $section ) {
 					$section = self::get_section_by_slug( $attr['slug'] );
 				}
 			}
@@ -42,7 +44,9 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 			if ( isset( $attr['id'] ) ) {
 				if ( $post ) {
 					$section = isset( $post->sections['posts'][$attr['id']] ) ? $post->sections['posts'][$attr['id']] : null;
-				} else {
+				}
+
+				if ( ! $section ) {
 					$section = get_post( $attr['id'] );
 				}
 			}


### PR DESCRIPTION
Bug Fixes:
* Sections that are not present in the post content were not processing properly because they weren't being pre-fetched during the `wp` hook. The logic has been updated to make sure if the section isn't found in the pre-fetched array, the code will go out and get it.