### PR TITLE
HF: Ensure that styles and scripts are loaded when using random shortcode attribute

### DIFF
--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -52,7 +52,13 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 			}
 
 			if ( !empty( $attr['random_from_tag'] ) ) {
-				$section = self::get_random_section( $attr['random_from_tag'] );
+				if ( $post ) {
+					$section = isset( $post->sections['posts'][$attr['random_from_tag']] ) ? $post->sections['posts'][$attr['random_from_tag']] : null;
+				}
+
+				if ( ! $section ) {
+					$section = self::get_random_section( $attr['random_from_tag'] );
+				}
 			}
 
 			if ( $section ) {
@@ -280,6 +286,11 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 						if ( isset( $args['id'] ) ) {
 							$section = get_post( $args['id'] );
 							$match = $args['id'];
+						}
+
+						if ( isset( $args['random_from_tag'] ) ) {
+							$section = self::get_random_section( $args['random_from_tag'] );
+							$match = $args['random_from_tag'];
 						}
 
 						if ( $section !== null ) {

--- a/includes/ucf-section-common.php
+++ b/includes/ucf-section-common.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'UCF_Section_Common' ) ) {
 
 			if ( isset( $attr['slug'] ) ) {
 				if ( $post ) {
-					$section =  isset( $post->sections['posts'][$attr['slug']] ) ? $post->sections['posts'][$attr['slug']] : null;
+					$section = isset( $post->sections['posts'][$attr['slug']] ) ? $post->sections['posts'][$attr['slug']] : null;
 				}
 
 				if ( ! $section ) {


### PR DESCRIPTION
**Description**
The custom styles and scripts for sections retrieved using the `random_from_tag` shortcode attribute were not getting loaded in a post.

**Motivation and Context**
To make sure that if styles/scripts are set, that they are loaded.

**How Has This Been Tested?**
Changes in DEV and QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
