### PR TITLE
Revert version requirement

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === UCF Sections ===
 Contributors: ucfwebcom
 Tags: ucf, sections
-Requires at least: 5.5.0
+Requires at least: 4.7.5
 Tested up to: 5.8
 Stable Tag: 1.2.0
 License: GPLv3 or later


### PR DESCRIPTION
**Description**
With the 'Requires at least' version being set to 5.5, the plugin will not activate on our WP envs currently on 5.3. It's been reverted to 4.7.5.

**Motivation and Context**
So we can activate the plugin on new sites.

**How Has This Been Tested?**
Plugin has now been successfully activated in QA after this change.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
